### PR TITLE
handle 0 padding and set nans/infty to 0

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -32,7 +32,18 @@ def main(checkpoint_path, image_path, save_path):
     pad_r = find_padding(image.shape[0])
     pad_c = find_padding(image.shape[1])
     image = np.pad(image, ((pad_r[0], pad_r[1]), (pad_c[0], pad_c[1]), (0, 0)), 'reflect')
+
+    # solve no-pad index issue after inference
+    if pad_r[1] == 0:
+        pad_r = (pad_r[0], 1)
+    if pad_c[1] == 0:
+        pad_c = (pad_c[0], 1)
+
     image = image.astype(np.float32)
+
+    # remove nans (and infinity) - replace with 0s
+    image = np.nan_to_num(image, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
+    
     image = image - np.min(image)
     image = image / np.maximum(np.max(image), 1)
 


### PR DESCRIPTION
Hello, ran into 2 issues when running DeepWaterMap that I think are easily resolvable.

1. If the image is exactly divisible by 32, then the padding indices are `pad_r == (0,0)` and `pad_c = (0,0)`. This causes a problem when trying to use these padding indices to resize the output image as indexing `dwm = dwm[0:-0, 0:-0]` returns an empty array. So by checking for 0s in the second values for the padding arrays and setting them to 1 if needed, this issue is resolved because `dwm = dwm[0:-1, 0:-1]` will return the entire array.


2. If there are any NaN or infinity values in the input image, then the pre-processing step where the image is normalized can turn the entire array into NaNs. One potential fix is to check for an NaNs or infinity values and raise an error right after loading the image, I propose simply replacing the values with 0s if they are present instead. 

These fixes appear to have resolved the problems I was running into. Again, not sure if they are the best solutions, but they're working for me. 